### PR TITLE
remove unneccessary import of JDK internal class (breaks build)

### DIFF
--- a/src/test/java/es/upm/etsisi/cf4j/recommender/knn/itemSimilarityMetric/SpearmanRankTest.java
+++ b/src/test/java/es/upm/etsisi/cf4j/recommender/knn/itemSimilarityMetric/SpearmanRankTest.java
@@ -6,7 +6,6 @@ import es.upm.etsisi.cf4j.data.MockDataSet;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static jdk.nashorn.internal.objects.Global.Infinity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/es/upm/etsisi/cf4j/recommender/knn/userSimilarityMetric/CorrelationTest.java
+++ b/src/test/java/es/upm/etsisi/cf4j/recommender/knn/userSimilarityMetric/CorrelationTest.java
@@ -6,7 +6,6 @@ import es.upm.etsisi.cf4j.data.User;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static jdk.nashorn.internal.objects.Global.Infinity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
Compiling the project failed for me because of these two imports of `jdk.nashorn.internal.objects.Global.Infinity`

Removing the unneeded import fixed it.
